### PR TITLE
shortened too long link in doc page

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -5,7 +5,8 @@ title: Documentation
 uid: documentation
 ---
 
-Installation documentation is now part of the source repository on [https://github.com/georchestra/georchestra/blob/master/README.md](https://github.com/georchestra/georchestra/blob/master/README.md).
+The installation and configuration documentation is now part of the source repository.  
+Please refer to the [README](https://github.com/georchestra/georchestra/blob/master/README.md) and explore the links.
 
 The **reference manuals** of the underlying standalone modules are also valuable sources of information:
 

--- a/es/documentacion.md
+++ b/es/documentacion.md
@@ -5,7 +5,7 @@ title: Documentacion
 uid: documentation
 ---
 
-Documentación de instalación es ahora parte del repositorio de código fuente en [https://github.com/georchestra/georchestra/blob/master/README.md](https://github.com/georchestra/georchestra/blob/master/README.md).
+Documentación de instalación es ahora parte del repositorio de código fuente en [README](https://github.com/georchestra/georchestra/blob/master/README.md).
 
 Los **manuales de referencia** de los módulos independientes subyacentes también son valiosas fuentes de información:
 

--- a/fr/documentation.md
+++ b/fr/documentation.md
@@ -5,7 +5,8 @@ title: Documentation
 uid: documentation
 ---
 
-La documentation d'installation est actuellement centralisée sur le dépôt du code source à l'adresse suivante : [https://github.com/georchestra/georchestra/blob/master/README.md](https://github.com/georchestra/georchestra/blob/master/README.md).
+La documentation d'installation et de configuration est centralisée sur le dépôt du code source, en langue anglaise.
+Vous pouvez y accéder depuis le fichier [README](https://github.com/georchestra/georchestra/blob/master/README.md) à la racine du projet.
 
 Il toujours utile de consulter les **documentations publiques** de référence des différents projets communautaires sous-jacents:
 


### PR DESCRIPTION
This long link was breaking the page on mobile.

As a result, this PR needs to be updated for the spanish side. Anyone ?

<!---
@huboard:{"order":14.0,"custom_state":"","milestone_order":31}
-->
