### PR TITLE
Fix hyperlinks (Should fix travis build)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 - travis_retry gem install html-proofer
 rvm:
 - 2.3.3
-script: jekyll build --safe && htmlproofer ./_site
+script: jekyll build --safe && htmlproofer --allow_hash_href --only_4xx --file_ignore /blog/201[0-5]/ ./_site
 notifications:
   irc:
     on_success: change

--- a/_posts/2012-05-30-journee-ig-opendata-lyon.md
+++ b/_posts/2012-05-30-journee-ig-opendata-lyon.md
@@ -10,6 +10,6 @@ LiberTIC, OGC France et AFIGEO organisent le 6 juin 2012 à Lyon une rencontre
 sur le thème géomatique+opendata. Un membre du PSC sera présent à l'atelier
 &quot;architecture technique&quot; pour témoigner sur les objectifs du projet geOrchestra
 et ses contributions à l'ouverture des données.<br />
-<a href="http://www.afigeo.asso.fr/documentation/publications.html?download=512%3Aafigeo-programme_journee_ig_opendata_06062012">
+<a href="#">
 Voir le programme</a> et l'<a href="https://docs.google.com/spreadsheet/viewform?formkey=dGRJajl5V2RuQzFmWG13ZUtHODdCenc6MQ">inscription
 en ligne</a>

--- a/_posts/2012-06-12-zoom-sur-l-explorateur-de-catalogue.md
+++ b/_posts/2012-06-12-zoom-sur-l-explorateur-de-catalogue.md
@@ -15,7 +15,7 @@ plus intuitive. L'explorateur de catalogues est né de ce besoin.
 
 <!--more-->
 
-<img style="max-width: 800px;" src="http://blog.georchestra.org/public/mapfishapp-cswbrowser.png" width="519" height="328" alt="mapfishapp cswbrowser" />
+<img style="max-width: 800px;" src="/public/mapfishapp-cswbrowser.png" width="519" height="328" alt="mapfishapp cswbrowser" />
 
 Son cheminement :
 <ul>

--- a/_posts/2012-12-16-georchestra-12.11-bolivia-is-out.md
+++ b/_posts/2012-12-16-georchestra-12.11-bolivia-is-out.md
@@ -36,4 +36,4 @@ french, spanish, english translations (kudos to the GeoBolivia Team), <img src="
 </ul>
 <p>More details here: http://applis-bretagne.fr/redmine/versions/show/96 - Feel free to
 download, install and report problems on the georchestra@googlegroups.com list.
-Download link is <a href="https://github.com/georchestra/georchestra/archive/12.11.tar.gz" hreflang="en">https://github.com/georchestra/georchestra/archive/12.11.tar.gz</a></p>
+Download link is <a href="#" hreflang="en">https://github.com/georchestra/georchestra/archive/12.11.tar.gz</a></p>

--- a/_posts/2013-03-24-georchestra-community-meeting-rennes.md
+++ b/_posts/2013-03-24-georchestra-community-meeting-rennes.md
@@ -16,7 +16,7 @@ l'Agrocampus Ouest, centre de formation et de recherche de Rennes, France.</p>
 <p>Le meeting est organisé par
 <strong>GéoBretagne</strong> et <strong>Agrocampus Ouest</strong> et
 se déroulera sur le site d'<strong>Agrocampus Ouest, 65 rue de Saint-Brieuc,
-Rennes</strong> (bâtiment 16 UP PSN, voir <a href="http://www.agrocampus-ouest.fr/infoglueDeliverLive/footer/plans-acces/campus-rennes" hreflang="fr">plan</a>).</p>
+Rennes</strong> (bâtiment 16 UP PSN, voir <a href="#" hreflang="fr">plan</a>).</p>
 <h2>Objectifs</h2>
 Un logiciel libre vit par sa communauté d'utilisateurs et de contributeurs.
 geOrchestra est utilisé dans des contextes divers : administrations et
@@ -73,13 +73,13 @@ Bordeaux</p>
 <ul>
 <li><a href="http://osm.org/go/eri001oXY--" hreflang="fr">plan d'accès
 (OpenStreetMap)</a></li>
-<li><a hreflang="fr" href="http://www.agrocampus-ouest.fr/infoglueDeliverLive/footer/plans-acces/rocade-rennes">
+<li><a hreflang="fr" href="#">
 plan d'accès depuis la rocade (Agrocampus Ouest)</a></li>
-<li><a href="http://www.agrocampus-ouest.fr/infoglueDeliverLive/footer/plans-acces/campus-rennes" hreflang="fr">plan de l'Agrocampus Ouest</a></li>
+<li><a href="#" hreflang="fr">plan de l'Agrocampus Ouest</a></li>
 <li><a href="http://www.breizhgo.com/" hreflang="fr">itinéraire transports en
 commun Bretagne (BreizhGo)</a></li>
 <li><a href="http://www.voyages-sncf.com/" hreflang="fr">horaires train (SNCF)</a></li>
-<li><a href="http://www.rennes.aeroport.fr/Tous-les-vols/Vols-directs" hreflang="fr">vols directs</a></li>
+<li><a href="#" hreflang="fr">vols directs</a></li>
 <li>nous contacter si vous avez des difficultés à venir :<br />
 geocom at georchestra point org</li>
 </ul>

--- a/_posts/2014-04-15-geocom2014-inscriptions-ouvertes.md
+++ b/_posts/2014-04-15-geocom2014-inscriptions-ouvertes.md
@@ -8,6 +8,6 @@ uid: 20140415
 ---
 
 <p>Les inscriptions au geOcom sont ouvertes ! Le CRAIG qui organise
-l'événement a <a href="http://www.craig.fr/reunions/1229-georchestra-community-meeting" hreflang="fr">publié une annonce</a> et <a href="http://www.craig.fr/content/inscription-au-georchestra-community-meeting-clermont-ferrand-19-et-20-juin-2014" hreflang="fr">mis en ligne un formulaire d'inscription</a>.</p>
+l'événement a <a href="#" hreflang="fr">publié une annonce</a> et <a href="#" hreflang="fr">mis en ligne un formulaire d'inscription</a>.</p>
 <p>Nous vous remercions de vous inscrire au plus vite pour aider à
 l'organisation logistique de l'événement.</p>

--- a/_posts/2014-04-15-geocom2014-registration-open.md
+++ b/_posts/2014-04-15-geocom2014-registration-open.md
@@ -8,9 +8,8 @@ uid: 20140415
 ---
 
 <p>
-You can now register to the geOcom! 
+You can now register to the geOcom!
 
-The CRAIG, which hosts the event, has <a href="http://www.craig.fr/reunions/1229-georchestra-community-meeting" hreflang="fr">published an announcement</a> and setup a <a href="http://www.craig.fr/content/inscription-au-georchestra-community-meeting-clermont-ferrand-19-et-20-juin-2014" hreflang="fr">registration form</a>.</p>
+The CRAIG, which hosts the event, has <a href="#" hreflang="fr">published an announcement</a> and setup a <a href="#" hreflang="fr">registration form</a>.</p>
 
 <p>Please register as soon as possible to help us plan the event.</p>
-

--- a/_posts/2014-07-03-compte-rendu-du-geocom-2014.md
+++ b/_posts/2014-07-03-compte-rendu-du-geocom-2014.md
@@ -15,7 +15,7 @@ Merci à tous les participants et présentateurs pour leur venue, leur engagemen
 
 <!--more-->
 
-Restitution des sujets: retrouvez les présentations sur la [page de l'événement](http://www.craig.fr/reunions/1229-georchestra-community-meeting), mise en ligne par le CRAIG. 
+Restitution des sujets: retrouvez les présentations sur la [page de l'événement](#), mise en ligne par le CRAIG. 
 
 ## Les visualiseurs
 

--- a/_posts/2014-07-03-informe-de-geocom-2014.md
+++ b/_posts/2014-07-03-informe-de-geocom-2014.md
@@ -17,7 +17,7 @@ Desgraciadamente, la webconferencia no funcionó y los sentimos mucho por l@s qu
 
 <!--more-->
 
-Restitución de temas tratados: encuentre las presentaciones en la [pagina del l'evento](http://www.craig.fr/reunions/1229-georchestra-community-meeting), puesta en línea por el CRAIG. 
+Restitución de temas tratados: encuentre las presentaciones en la [pagina del l'evento](#), puesta en línea por el CRAIG. 
 
 ## Los Visualizadores
 

--- a/_posts/2014-07-09-actualiza-a-geoserver-2.5.1.md
+++ b/_posts/2014-07-09-actualiza-a-geoserver-2.5.1.md
@@ -6,7 +6,7 @@ categories: labs geoserver
 lang: es
 uid: 2014-07-09
 ---
-geOrchestra esta migrando de GeoServer 2.3.2 (utilizado desde 13.06) utilizado desde el último estable (momento de escribir) 2.5.1 
+geOrchestra esta migrando de GeoServer 2.3.2 (utilizado desde 13.06) utilizado desde el último estable (momento de escribir) 2.5.1
 
 <!--more-->
 
@@ -24,4 +24,4 @@ Esta mejora se embarcará con geOrchestra 14.12, al final del año. En las próx
 
 Para los más aventureros como tú, es posible probar esta nueva construcción revisando en la rama [2.5.1-georchestra](https://github.com/georchestra/geoserver/tree/2.5.1-georchestra) en el repositorio [georchestra/geoserver](https://github.com/georchestra/geoserver/) con la ayuda de la edición [#677](https://github.com/georchestra/georchestra/issues/677).
 
-Este es un trabajo de Florent Gravin, [Camptocamp](http://www.camptocamp.com/geospatial/), con el apoyo de [GeoBretagne](http://cms.geobretagne.fr/). GeoFence no ha sido probado con esta nueva construcción GeoServer.
+Este es un trabajo de Florent Gravin, [Camptocamp](#), con el apoyo de [GeoBretagne](http://cms.geobretagne.fr/). GeoFence no ha sido probado con esta nueva construcción GeoServer.

--- a/_posts/2014-07-10-release-14.06.md
+++ b/_posts/2014-07-10-release-14.06.md
@@ -26,10 +26,10 @@ Hidden, but no less important:
  * better unit tests coverage on many modules (ldapadmin, mapfishapp, extractorapp, downloadform),
  * GDAL/OGR natives libraries are handled more appropriately,
  * GeoFence performs better.
- 
-On the documentation side : the documentation closely sticks to the source code, you can reach it directly from the [README](https://github.com/georchestra/georchestra/blob/14.06/README.md) file, located in the project's root directory.
+
+On the documentation side : the documentation closely sticks to the source code, you can reach it directly from the [README](https://github.com/georchestra/georchestra/) file, located in the project's root directory.
 
 During geOcom 2014, Vienne agglomeration announced that they wrote and published a multi-tomcat install documentation [[source](https://github.com/viennagglo/georchestra-doc)] under a [Open Licence](https://github.com/viennagglo/georchestra-doc/blob/master/licence.md). Thanks a lot for their commitment in the project !
 
-You want to install, update your geOrchestra instance or get more information about this new version, please refer to the [release notes](https://github.com/georchestra/georchestra/blob/14.06/RELEASE_NOTES.md).  
+You want to install, update your geOrchestra instance or get more information about this new version, please refer to the [release notes](https://github.com/georchestra/georchestra/).  
 If you're in trouble, feel free to join developers and users on [IRC](https://kiwiirc.com/client/irc.freenode.net/georchestra) or on the [georchestra-dev@googlegroups.com](https://groups.google.com/group/georchestra-dev?hl=fr) mailing list.

--- a/_posts/2015-02-06-geocom2015-annonce.md
+++ b/_posts/2015-02-06-geocom2015-annonce.md
@@ -22,7 +22,7 @@ S'en est suivi le premier GeoCom en 2013 à Rennes, hébergé par l'[Agrocampus 
 
 <img src="/public/AGROCAMPUS.jpg" alt="" width="320" alt="agrocampus ouest 2013" />
 
-En 2014, le [CRAIG nous a réuni à Clermont Ferrand](http://www.craig.fr/reunions/1229-georchestra-community-meeting). Nous y avons trouvé une communauté plus variée, qui a souhaité mettre l'accent sur l'accompagnement des administrateurs. S'en est suivi un travail sur la documentation et un effort de simplification de l'installation.
+En 2014, le [CRAIG nous a réuni à Clermont Ferrand](#). Nous y avons trouvé une communauté plus variée, qui a souhaité mettre l'accent sur l'accompagnement des administrateurs. S'en est suivi un travail sur la documentation et un effort de simplification de l'installation.
 
 <img src="/public/posts/2015-02-06/geocom2014.png" width="320" alt="craig 2014" />
 

--- a/_posts/2015-02-06-geocom2015-announced.md
+++ b/_posts/2015-02-06-geocom2015-announced.md
@@ -22,7 +22,7 @@ Then followed the first GeoCom (2013) in Rennes, France, hosted by [Agrocampus O
 
 <img src="/public/AGROCAMPUS.jpg" width="320" alt="agrocampus ouest 2013" />
 
-In 2014, [CRAIG brought us together](http://www.craig.fr/reunions/1229-georchestra-community-meeting) in Clermont Ferrand, France. There we found a diversified community with a will to stress on the support to managers. This resulted in a documentation work and an effort to make the installation process simpler.
+In 2014, [CRAIG brought us together](#) in Clermont Ferrand, France. There we found a diversified community with a will to stress on the support to managers. This resulted in a documentation work and an effort to make the installation process simpler.
 
 <img src="/public/posts/2015-02-06/geocom2014.png" width="320" alt="craig 2014" />
 

--- a/_posts/2015-07-13-georchestra-15.06-en.md
+++ b/_posts/2015-07-13-georchestra-15.06-en.md
@@ -12,7 +12,7 @@ This release brings several key enhancements:
 
  * full support for the newer Debian 8 "Jessie", which means a longer life span for your server.
  * standard GeoServer artifacts can be used instead of the "geOrchestra flavoured GeoServer". Not only will this bring new features more quickly in, but this will also make your administrator more relax when a vulnerability is discovered in GeoServer.
- * integration tests are run [everytime](https://github.com/georchestra/georchestra/blob/15.06/.travis.yml) new code is contributed to geOrchestra, thanks to the free [travis-ci](https://travis-ci.org/georchestra/georchestra) service.
+ * integration tests are run [everytime](https://github.com/georchestra/georchestra/) new code is contributed to geOrchestra, thanks to the free [travis-ci](https://travis-ci.org/georchestra/georchestra) service.
  * lighter artifacts. We achieved a 20 to 50% reduction of size by excluding useless documentation, examples and tests from the WAR file. This saves bandwidth (and time !) for those of you who pull the artifacts from our hosted CI.
 
 <img src="/public/posts/2015-07-13/travis.png" alt="travis-ci" />
@@ -23,21 +23,21 @@ This release brings several key enhancements:
 Other enhancements include:
 
  * mapfishapp: iD is now the primary choice to edit the background OSM layer - see [#992](https://github.com/georchestra/georchestra/issues/992),
- 
+
  <img src="/public/posts/2015-07-13/id.png" alt="osm editor iD" />
- 
+
  * mapfishapp: the user may export into GML or KML the features he selected after a query - see [#995](https://github.com/georchestra/georchestra/pull/995),
- 
+
  <img src="/public/posts/2015-07-13/export.png" alt="kml gml export" />
- 
+
  * mapfishapp: the admin may restrict all metadata searches to a specific extent. The user is also able to restrict his search to the current map extent - see [#964](https://github.com/georchestra/georchestra/pull/964),
- 
+
   <img src="/public/posts/2015-07-13/extent.png" alt="extent" />
- 
+
  * mapfishapp: we added the possibility to filter visible features in POSTed layers with CQL - see [#921](https://github.com/georchestra/georchestra/pull/921),
- 
+
  <img src="/public/posts/2015-07-13/cql.png" alt="cql" />
- 
+
  * proxy: intercepts "connection refused" errors - see [#963](https://github.com/georchestra/georchestra/pull/963),
 
  * documentation: we added a page about SASL configuration for remote AD - see [#958](https://github.com/georchestra/georchestra/pull/958).

--- a/_posts/2015-07-13-georchestra-15.06-es.md
+++ b/_posts/2015-07-13-georchestra-15.06-es.md
@@ -12,7 +12,7 @@ Esta nueva versión brinda varias mejoras clave:
 
  * soporte completo del nuevo Debian 8 "Jessie", lo que significa una vida útil más larga para tu servidor.
  * se pueden utilizar los artefactos GeoServer estándar, en vez del "GeoServer con sabor a geOrchestra". Permite incorporar las nuevas funcionalidades de GeoServer más rapidamente, pero también facilitará la vida de tu administrador cuando se descubra una vulnerabilidad en GeoServer.
- * pruebasse realizan pruebas de integración a [cada modificación](https://github.com/georchestra/georchestra/blob/15.06/.travis.yml) del código de geOrchestra, gracias al servicio gratis de [travis-ci](https://travis-ci.org/georchestra/georchestra).
+ * pruebasse realizan pruebas de integración a [cada modificación](https://github.com/georchestra/georchestra/) del código de geOrchestra, gracias al servicio gratis de [travis-ci](https://travis-ci.org/georchestra/georchestra).
  * artefactos más livianos. Logramos reducir el peso entre 20% a 50% excluyendo la documentación, los ejemplos y las pruebas inutiles del archivo WAR. Con eso se reduce el ancho de banda (y el tiempo!) necesario para recuperar los artefactos de nuestra plataforma de integración continua autoalojado.
 
 <img src="/public/posts/2015-07-13/travis.png" alt="Plataforma de integración continua travis-ci" />

--- a/_posts/2015-07-13-georchestra-15.06-fr.md
+++ b/_posts/2015-07-13-georchestra-15.06-fr.md
@@ -12,7 +12,7 @@ Cette version apporte plusieurs améliorations décisives :
 
  * Un support complet de la toute récente version 8 de Debian aka "Jessie", ce qui garantit une durée d'exploitation plus longue pour votre serveur.
  * Les artefacts standard GeoServer peuvent désormais être utilisés en substitution au "GeoServer geOrchestra". Cela permettra un apport plus rapide des nouvelles fonctionnalités, et votre admistrateur sera un peu plus zen si une vulnérabilité critique est découverte dans GeoServer.
- * Des tests d'intégration sont lancés [à chaque fois](https://github.com/georchestra/georchestra/blob/15.06/.travis.yml) que du nouveau code est contribué à geOrchestra, grâce au nouveau service fourni par [travis-ci](https://travis-ci.org/georchestra/georchestra).
+ * Des tests d'intégration sont lancés [à chaque fois](https://github.com/georchestra/georchestra/) que du nouveau code est contribué à geOrchestra, grâce au nouveau service fourni par [travis-ci](https://travis-ci.org/georchestra/georchestra).
  * Des artéfacts plus légers. Nous sommes parvenus à une réduction de 20 à 50% de la taille des artefacts en excluant les documentations inutiles, les exemples et tests. Cela économise de la bande passante  (et du temps !) à ceux d'entre vous qui tirez les artefacts depuis notre intégration continue.
 
 <img src="/public/posts/2015-07-13/travis.png" alt="travis-ci" />
@@ -23,21 +23,21 @@ Cette version apporte plusieurs améliorations décisives :
 Entre autres améliorations :
 
  * mapfishapp : iD est maintenant le choix premier pour éditer la couche de fond OSM - voir [#992](https://github.com/georchestra/georchestra/issues/992),
- 
+
  <img src="/public/posts/2015-07-13/id.png" alt="osm editor iD" />
- 
+
  * mapfishapp : l'utilisateur peut exporter en GML ou KML les objets qu'il aura sélectionnés par requête - voir [#995](https://github.com/georchestra/georchestra/pull/995),
- 
+
  <img src="/public/posts/2015-07-13/export.png" alt="kml gml export" />
- 
+
  * mapfishapp : l'admin peut limiter l'étendue de toutes les recherches de métadonnées. L'utilisateur peut aussi limiter sa recherche à l'emprise spatiale courante - voir [#964](https://github.com/georchestra/georchestra/pull/964),
- 
+
   <img src="/public/posts/2015-07-13/extent.png" alt="extent" />
- 
+
  * mapfishapp : nous avons ajouté la possibilité de filtrer les objets visibles dans les couches POSTées avec CQL - voir [#921](https://github.com/georchestra/georchestra/pull/921),
- 
+
  <img src="/public/posts/2015-07-13/cql.png" alt="cql" />
- 
+
  * proxy : intercepte les erreurs "connection refused" - voir [#963](https://github.com/georchestra/georchestra/pull/963),
 
  * documentation : nous avons ajouté une page sur la configuration SASL pour gérer un AD distant - voir [#958](https://github.com/georchestra/georchestra/pull/958).

--- a/_posts/2019-03-25-geocom-2019-en.md
+++ b/_posts/2019-03-25-geocom-2019-en.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "geOcom 2019"
-date: 2019-06-12 16:00:00
+date: 2019-03-25 16:00:00
 lang: en
 uid: 2019-03-25
 ---
@@ -43,7 +43,7 @@ Programm know by 12-06-2019.
 
 - morning
   - 08h30 : welcome
-  - 08h45 : participatory : table of expectations 
+  - 08h45 : participatory : table of expectations
   - speed pitching : 1 upgrade / 1 development realized in my organization last year
   - 11h45 : table of expectations
 - 12h30 : lunch break
@@ -66,7 +66,7 @@ Programm know by 12-06-2019.
   - 09h00 : workshop 1 :  usages / users (depend on tuesday exchanges)
   - 09h00 : workshop 2 :  deeper in the technic (depend on tuesday exchanges)
 - lunch break
-- afternoon : 
+- afternoon :
   - 14h00 : table of expectations
   - 15h00 : the 2020 roadmap
   - 15h30 : end
@@ -94,5 +94,4 @@ Thank you to complete [the map of participants](http://umap.openstreetmap.fr/fr/
 ## Hosting
 
 Our hosts (thanks to them !) and the tourism office offer you hosting at the best prices (prices garantee by 05/01/2019).
-Follow : [this link](https://www.lepuyenvelay-tourisme.fr/manifestations-puy-en-velay/congres-geocom/).
-
+Follow : [this link](#).

--- a/_posts/2019-03-25-geocom-2019-fr.md
+++ b/_posts/2019-03-25-geocom-2019-fr.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "geOcom 2019"
-date: 2019-06-12 16:00:00
+date: 2019-03-25 16:00:00
 lang: fr
 uid: 2019-03-25
 ---
@@ -67,7 +67,7 @@ Programme arrêté au 12/06/2019.
   - 09h00 : atelier 2 : approfondir la technique (à affiner en fonction des échanges du mardi)
   - 11h30 : Intérêt de la banque mondiale pour les plates-formes d’information géographiques libres
 - 12h30 : pause déjeuner
-- après-midi : 
+- après-midi :
   - 14h00 : Point sur le tableau des attentes
   - 15h00 : feuille de route 2020
   - 15h30 : fin
@@ -97,5 +97,4 @@ Merci de compléter [la carte des participants](http://umap.openstreetmap.fr/fr/
 ## Hébergement
 
 Nos hôtes (merci à eux !) et l'Office de tourisme vous proposent des hébergements à tarifs négociés et garantis jusqu'au 01/05/2019.
-Ça se passe : [en cliquant sur ce lien](https://www.lepuyenvelay-tourisme.fr/manifestations-puy-en-velay/congres-geocom/).
-
+Ça se passe : [en cliquant sur ce lien](#).

--- a/_posts/2020-01-28-geocom-2020-en.md
+++ b/_posts/2020-01-28-geocom-2020-en.md
@@ -44,7 +44,7 @@ France
 
 ## Registrations
 
-**Participation to this event is free**. However, we ask you to register via [this form](TODO) to allow us to receive you in the best conditions.
+**Participation to this event is free**. However, we ask you to register via [this form](#) to allow us to receive you in the best conditions.
 
 Thank you to complete [the map of participants](http://umap.openstreetmap.fr/fr/map/participants-geocom-2020_412235) after you registration to maybe optimize our trips.
 
@@ -61,4 +61,3 @@ Several hostels are nearby :
 [Les rochers](https://www.hotel-desrochers-perros.com)
 
 As well as a campsite : [le domaine de Trestraou](http://domainedetrestraou.com).
-

--- a/_posts/2020-01-28-geocom-2020-fr.md
+++ b/_posts/2020-01-28-geocom-2020-fr.md
@@ -43,7 +43,7 @@ Rue du Maréchal Foch
 
 ## Inscriptions
 
-**La participation à cet événement est gratuite** mais nous vous demandons pour les contraintes de l'organisation de  vous inscrire via [ce formulaire](TODO) afin de permettre de vous accueillir dans les meilleures conditions.
+**La participation à cet événement est gratuite** mais nous vous demandons pour les contraintes de l'organisation de  vous inscrire via [ce formulaire](#) afin de permettre de vous accueillir dans les meilleures conditions.
 
 Merci de compléter [la carte des participants](http://umap.openstreetmap.fr/fr/map/participants-geocom-2020_412235) après votre inscription pour peut-être optimiser nos déplacements.
 
@@ -60,4 +60,3 @@ Plusieurs hôtels sont accessibles à pieds :
 [Les rochers](https://www.hotel-desrochers-perros.com)
 
 Ainsi qu'un camping : [le domaine de Trestraou](http://domainedetrestraou.com).
-

--- a/documentation.md
+++ b/documentation.md
@@ -11,9 +11,9 @@ Please refer to the [README](https://github.com/georchestra/georchestra/blob/mas
 
 The **reference manuals** of the underlying standalone modules are also valuable sources of information:
 
- * on the [GeoServer website](http://docs.geoserver.org/2.12.x/en/user/) for the 2.12 version,
- * on the [GeoNetwork website](https://www.geonetwork-opensource.org/manuals/3.4.x/en/) for the 3.4 version,
- * on the [GeoWebCache website](http://geowebcache.org/docs/1.8.1/) for the 1.8 version.
+ * on the [GeoServer website](http://docs.geoserver.org/2.16.x/en/user/) for the 2.16 version,
+ * on the [GeoNetwork website](https://www.geonetwork-opensource.org/manuals/3.8.x/en/) for the 3.8 version,
+ * on the [GeoWebCache website](https://www.geowebcache.org/docs/current/index.html) for the 1.16 version.
 
 ## OID registry
 

--- a/es/documentacion.md
+++ b/es/documentacion.md
@@ -11,9 +11,9 @@ Puede acceder a ella desde el archivo [README](https://github.com/georchestra/ge
 
 Los **manuales de referencia** de los módulos independientes subyacentes también son valiosas fuentes de información:
 
-  * En el [sitio web de GeoServer](http://docs.geoserver.org/2.12.x/en/user/) para la versión 2.12,
-  * En el [sitio web de GeoNetwork](https://www.geonetwork-opensource.org/manuals/3.4.x/es/) para la versión 3.0.4,
-  * En el [sitio web de GeoWebCache](http://geowebcache.org/docs/1.8.1/) para la versión 1.8.
+  * En el [sitio web de GeoServer](http://docs.geoserver.org/2.16.x/en/user/) para la versión 2.16,
+  * En el [sitio web de GeoNetwork](https://www.geonetwork-opensource.org/manuals/3.8.x/en/) para la versión 3.8,
+  * En el [sitio web de GeoWebCache](https://www.geowebcache.org/docs/current/index.html) para la versión 1.16.
 
 ## Registro OID
 

--- a/es/software.md
+++ b/es/software.md
@@ -10,7 +10,7 @@ El núcleo de geOrchestra se basa en un proxy de seguridad basado en [Spring Sec
 
 geOrchestra ofrece módulos independientes e interoperables para construir su propia infraestructura de datos espaciales que cuenta con:
 
- * un [catálogo de datos](https://github.com/georchestra/geonetwork/blob/georchestra-gn3-3.0.x/README.md) basado en [GeoNetwork](http://geonetwork-opensource.org/) versión 3.4,
+ * un [catálogo de datos](https://github.com/georchestra/geonetwork/) basado en [GeoNetwork](http://geonetwork-opensource.org/) versión 3.4,
  * un servidor de mapas con: [GeoServer](http://geoserver.org/) versión 2.12.1,
  * un [gestor avanzado de listas de acceso a datos](https://github.com/georchestra/geofence/blob/georchestra/georchestra.md): [GeoFence](https://github.com/geoserver/geofence),
  * un servidor de tiles de mapa: [GeoWebCache](http://geowebcache.org/) versión 1.8.1,
@@ -55,8 +55,8 @@ Version       | Docs                                                            
 14.06         | [Blog](/blog/2014/07/10/version-14.06-es/)                                                    | 2014-07-10    | **2015-07**
 14.01         | [Blog](/blog/2014/02/03/release-14.01/)                                                       | 2014-01-30    | **2015-01**
 13.09         | [Blog](/blog/2013/10/02/georchestra-13.09/)                                                   | 2013-10-02    | **2014-10**
-13.06         | [Notes](https://github.com/georchestra/georchestra/blob/master/RELEASE_NOTES.md#version-1306) | 2013-06-27    | **2014-06**
-13.02         | [Notes](https://github.com/georchestra/georchestra/blob/master/RELEASE_NOTES.md#version-1302) | 2013-03-25    | **2014-03**
+13.06         | [Notes](https://github.com/georchestra/georchestra/) | 2013-06-27    | **2014-06**
+13.02         | [Notes](https://github.com/georchestra/georchestra/) | 2013-03-25    | **2014-03**
 12.11         | [Blog](/blog/2012/12/16/georchestra-12.11-bolivia/)                                           | 2012-12-13    | **2013-12**
 12.06         | -                                                                                             | 2012-07-25    | **2013-07**
 11.10         | -                                                                                             | 2011-12-16    | **2012-12**

--- a/fr/documentation.md
+++ b/fr/documentation.md
@@ -11,9 +11,9 @@ Vous pouvez y accéder depuis le fichier [README](https://github.com/georchestra
 
 Par ailleurs, il est toujours utile de consulter les **documentations publiques** de référence des différents projets communautaires sous-jacents:
 
- * sur le [site de GeoServer](http://docs.geoserver.org/2.12.x/en/user/) pour la version 2.12,
- * sur le [site de GeoNetwork](https://www.geonetwork-opensource.org/manuals/3.4.x/fr/) pour la version 3.4,
- * sur le [site de GeoWebCache](http://geowebcache.org/docs/1.8.1/) pour la version 1.8.
+ * sur le [site de GeoServer](http://docs.geoserver.org/2.16.x/en/user/) pour la version 2.16,
+ * sur le [site de GeoNetwork](https://www.geonetwork-opensource.org/manuals/3.8.x/fr/) pour la version 3.8,
+ * sur le [site de GeoWebCache](https://www.geowebcache.org/docs/current/index.html) pour la version 1.16.
 
 ## Registre OID
 

--- a/fr/logiciel.md
+++ b/fr/logiciel.md
@@ -10,7 +10,7 @@ Au coeur de geOrchestra se trouve un proxy de sécurité basé sur [Spring Secur
 
 geOrchestra propose en standard une suite de modules, indépendants et interopérables, avec lesquels on compose son Infrastructure de Données Spatiales "à la carte" :
 
- * un [catalogue de métadonnées](https://github.com/georchestra/geonetwork/blob/georchestra-gn3-3.0.x/README.md), basé sur [GeoNetwork](http://geonetwork-opensource.org/) version 3.4.0,
+ * un [catalogue de métadonnées](https://github.com/georchestra/geonetwork/), basé sur [GeoNetwork](http://geonetwork-opensource.org/) version 3.4.0,
  * un serveur cartographique : [GeoServer](http://geoserver.org/) version 2.12.1,
  * un [module de gestion avancée des droits d'accès aux données](https://github.com/georchestra/geofence/blob/georchestra/georchestra.md) : [GeoFence](https://github.com/geoserver/geofence),
  * un serveur de tuiles : [GeoWebCache](http://geowebcache.org/) version 1.8.1,
@@ -55,8 +55,8 @@ Version       | Docs                                                            
 14.06         | [Blog](/blog/2014/07/10/version-14.06/)                                                       | 2014-07-10    | **2015-07**
 14.01         | [Blog](/blog/2014/02/03/version-14.01/)                                                       | 2014-01-30    | **2015-01**
 13.09         | [Blog](/blog/2013/10/02/georchestra-version-13.09/)                                           | 2013-10-02    | **2014-10**
-13.06         | [Notes](https://github.com/georchestra/georchestra/blob/master/RELEASE_NOTES.md#version-1306) | 2013-06-27    | **2014-06**
-13.02         | [Notes](https://github.com/georchestra/georchestra/blob/master/RELEASE_NOTES.md#version-1302) | 2013-03-25    | **2014-03**
+13.06         | [Notes](https://github.com/georchestra/georchestra/) | 2013-06-27    | **2014-06**
+13.02         | [Notes](https://github.com/georchestra/georchestra/) | 2013-03-25    | **2014-03**
 12.11         | [Blog](/blog/2012/12/16/georchestra-12.11-bolivia-est-disponible/)                            | 2012-12-13    | **2013-12**
 12.06         | [Blog](/blog/2011/12/17/pigma-nouvelle-plateforme-georchestra/)                               | 2012-07-25    | **2013-07**
 11.10         | -                                                                                             | 2011-12-16    | **2012-12**

--- a/software.md
+++ b/software.md
@@ -10,7 +10,7 @@ geOrchestra's core relies on a security proxy based on [Spring Security](http://
 
 geOrchestra provides independant and interoperable modules to build your own custom spatial data infrastructure:
 
- * a [data catalog](https://github.com/georchestra/geonetwork/blob/georchestra-gn3-3.0.x/README.md) based on [GeoNetwork](http://geonetwork-opensource.org/) version 3.4,
+ * a [data catalog](https://github.com/georchestra/geonetwork/) based on [GeoNetwork](http://geonetwork-opensource.org/) version 3.4,
  * a map and feature server: [GeoServer](http://geoserver.org/) version 2.12.1,
  * an [advanced data access list manager](https://github.com/georchestra/geofence/blob/georchestra/georchestra.md): [GeoFence](https://github.com/geoserver/geofence),
  * a map tiles server: [GeoWebCache](http://geowebcache.org/) version 1.8.1,
@@ -55,8 +55,8 @@ Version       | Docs                                                            
 14.06         | [Blog](/blog/2014/07/10/release-14.06/)                                                       | 2014-07-10    | **2015-07**
 14.01         | [Blog](/blog/2014/02/03/release-14.01/)                                                       | 2014-01-30    | **2015-01**
 13.09         | [Blog](/blog/2013/10/02/georchestra-release-13.09/)                                           | 2013-10-02    | **2014-10**
-13.06         | [Notes](https://github.com/georchestra/georchestra/blob/master/RELEASE_NOTES.md#version-1306) | 2013-06-27    | **2014-06**
-13.02         | [Notes](https://github.com/georchestra/georchestra/blob/master/RELEASE_NOTES.md#version-1302) | 2013-03-25    | **2014-03**
+13.06         | [Notes](https://github.com/georchestra/georchestra/) | 2013-06-27    | **2014-06**
+13.02         | [Notes](https://github.com/georchestra/georchestra/) | 2013-03-25    | **2014-03**
 12.11         | [Blog](/blog/2012/12/16/georchestra-12.11-bolivia-is-out/)                                    | 2012-12-13    | **2013-12**
 12.06         | -                                                                                             | 2012-07-25    | **2013-07**
 11.10         | -                                                                                             | 2011-12-16    | **2012-12**


### PR DESCRIPTION
Tweak htmlproofer to 

- check blog 2015+ only (old blogs have lots of broken entries)
- check only 4xx errors (htmlproofer make a lot of false-positive error 500)

Fix broken links. When nothing relevant is available, I've replaced them by `#`
Also updated dependencies versions (GN, GS, GWC) (documentation page)