### PR TITLE
Update build_and_test_website.yml

### DIFF
--- a/.github/workflows/build_and_test_website.yml
+++ b/.github/workflows/build_and_test_website.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build the site in the jekyll/builder container
       run: |
         docker run \


### PR DESCRIPTION
update actions/checkout@v3 for node.js 16 : https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/