### PR TITLE
Video into a link

### DIFF
--- a/public/geocom2023/geocom-2023.html
+++ b/public/geocom2023/geocom-2023.html
@@ -36,18 +36,11 @@ permalink: /fr/geocom2023/geocom-2023.html
   {% include card_user.html label_site="Visualiser" name="Cas d’usages - Mapstore pour faire de la mise à jour de données : exemple de mise en oeuvre" text="Maël REBOUX (Rennes Métropole)" site_url="../../public/geocom2023/presentation/geocom_2023_mapstore_maj_donnees.pdf" %}
   {% include card_user.html label_site="Visualiser" name="Cas d’usages - MapStore 3D" text="Landry BREUIL (CRAIG)" site_url="../../public/geocom2023/presentation/20230531_mapstore_3d.pdf" %}
   {% include card_user.html label_site="Visualiser" name="Cas d’usages - Plugin IDG pour QGIS" text="Jean-Baptiste DESBAS & Benjamin CHARTIER (Geo2France)" site_url="../../public/geocom2023/presentation/geocom_2023_plugin_qgis.pdf" %}
+  {% include card_user.html label_site="Voir la vidéo" name="Cas d’usages : geOrchestra comme plateforme de téléchargement de données OSM" text="Séverin MENARD (Les libres géographes)" site_url="../../public/geocom2023/presentation/GeoCom2013_intervention_Severin_donnees_OSM_20230531.webm" %}
   {% include card_user.html label_site="Visualiser" name="Renouvellement des briques (Gateway vs Security-proxy, header, extracteur, atlas,… )" text="Pierre MAUDUIT & François VAN DER BIEST (Camptocamp)" site_url="../../public/geocom2023/presentation/Camptocamp-geOcom23-RenouvellementBriques.pdf" %}
   {% include card_user.html label_site="Visualiser" name="Refonte de l’édition de métadonnées & OpenData avec geonetwork 4 / datahub" text="Florent GRAVIN (Camptocamp)" site_url="../../public/geocom2023/presentation/Camptocamp-geOcom23-geonetworkEditorDatahub.pdf" %}
   {% include card_user.html label_site="Visualiser" name="geOrchestra et Kubernetes" text="Emilien DEVOS & Jean-Michel CREPEL(Camptocamp)" site_url="../../public/geocom2023/presentation/Camptocamp-geOcom23-Kubernetes.pdf" %}
   {% include card_user.html label_site="Visualiser" name="Amélioration des statistiques d’usage" text="Jean POMMIER (Indépendant)" site_url="../../public/geocom2023/presentation/AmeliorationsStatsUsages.pdf" %}
   {% include card_user.html label_site="Visualiser" name="Utiliser Geomapfish avec geOrchestra" text="Yves JACOLIN (Camptocamp)" site_url="../../public/geocom2023/presentation/Camptocamp-geOcom23-GeoMapFish.pdf" %}
   {% include card_user.html label_site="Visualiser" name="Financement - Etat des lieux : comment on a fait jusqu’à présent" text="Landry BREUIL, François VAN DER BIEST & Frédéric DENEUX (visio)" site_url="../../public/geocom2023/presentation/montage_mapstore2.pdf" %}
-</div>
-<div>
-  <h5>Cas d’usages : geOrchestra comme plateforme de téléchargement de données OSM</h5>
-  <p>Séverin MENARD (Les libres géographes)</p>
-  <video width="100%" height="auto" controls>
-    <source src="../../public/geocom2023/presentation/GeoCom2013_intervention_Severin_donnees_OSM_20230531.webm" type="video/webm">
-	  Oups ! La vidéo ne semble pas fonctionner ...
-  </video>
 </div>


### PR DESCRIPTION
@fvanderbiest , comme souhaité https://github.com/georchestra/georchestra.github.io/pull/141#issuecomment-1860383531, la vidéo des lib géographes est maintenant présentée comme les autres supports et accessible depuis un lien dans un nouvel onglet. Merci pour ton conseil, je trouve cela mieux également ;) 
![image](https://github.com/georchestra/georchestra.github.io/assets/22764056/06360e6c-78b5-4318-8526-3a8e50d29524)
